### PR TITLE
docs: add CODE_OF_CONDUCT.md for community guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,122 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- **Being respectful and inclusive** in language and actions
+- **Being collaborative** and working together toward common goals
+- **Being constructive** when giving feedback or suggestions
+- **Being empathetic** toward other community members
+- **Being patient** with newcomers and those learning
+- **Being open to different viewpoints** and experiences
+- **Being accountable** for our actions and their impact
+- **Focusing on what's best** for the community and the project
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, or sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+- Dismissing or attacking inclusion-oriented requests
+- Advocating for, or encouraging, any of the above behavior
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [contact@qroom.app](mailto:contact@qroom.app). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+
+---
+
+## Qroom-Specific Guidelines
+
+### Project Context
+Qroom is an open-source real-time audience interaction platform that enables engaging presentations, live polls, and Q&A sessions. Our community values:
+
+- **Educational excellence** - We support learning and knowledge sharing
+- **Inclusive participation** - Everyone should feel welcome to contribute
+- **Real-time collaboration** - We value efficient and effective communication
+- **Open source principles** - Transparency, collaboration, and community-driven development
+
+### Hacktoberfest Participation
+As a Hacktoberfest-friendly project, we especially welcome:
+
+- First-time contributors and newcomers
+- Documentation improvements
+- Bug fixes and feature enhancements
+- UI/UX improvements
+- Testing and quality assurance contributions
+
+### Communication Channels
+- **GitHub Issues**: For bug reports, feature requests, and discussions
+- **GitHub Discussions**: For general community conversations
+- **Pull Requests**: For code contributions and reviews
+- **Email**: [contact@qroom.app](mailto:contact@qroom.app) for private matters
+
+### Getting Help
+If you need help or have questions:
+1. Check our [Contributing Guide](CONTRIBUTING.md)
+2. Search existing [Issues](https://github.com/kkhushie/qroom/issues) and [Discussions](https://github.com/kkhushie/qroom/discussions)
+3. Create a new issue with the appropriate label
+4. Reach out to maintainers if needed
+
+---
+
+**Remember**: This is a community project built with ❤️ by contributors worldwide. Let's work together to make Qroom an amazing platform for audience engagement!


### PR DESCRIPTION
### Description
This PR adds a `CODE_OF_CONDUCT.md` file to define community behavior guidelines.

### Why
Establishing clear communication and conduct standards improves inclusivity and sets expectations for all contributors.

### Notes
- Based on the Contributor Covenant v2.1
- Can be updated later with maintainer contact info if needed

Closes #20 
